### PR TITLE
Add CNAME to github pages deploy step

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,3 +22,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build
+          cname: melbournecocoaheads.com


### PR DESCRIPTION
Previously, a deployment would clear out the `melbournecocoaheads.com` custom domain setting from the GitHub Pages settings. Adding a `cname` argument to the deploy step will keep it in.

This is part of the [`peace iris/actions-gh-pages` action](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-add-cname-file-cname ).

(It looks like `.con` because the font is cut off. It's set to `.com`)
![Screen Shot 2020-08-02 at 14 00 58](https://user-images.githubusercontent.com/790199/89115194-b39a4100-d4c8-11ea-837f-7da7834e338f.png)
