### PR TITLE
Add acknowledgement of country

### DIFF
--- a/source/layouts/partials/footer.html
+++ b/source/layouts/partials/footer.html
@@ -32,4 +32,7 @@
     <div class="copyright">
         <small>Copyright © {{ now.Format "2006"}} Melbourne CocoaHeads Inc.<br/> All rights reserved.</small>
     </div>
+    <div class="acknowledgement">
+        <small>Melbourne CocoaHeads acknowledge the people of the Kulin nations as the Traditional Custodians of the land on which we live and work, recognising their continuing connection to land, water and community. We pay our respects to them and their cultures and to elders both past and present.​ </small>
+    </div>
 </footer>

--- a/source/static/style.css
+++ b/source/static/style.css
@@ -21,7 +21,7 @@
         --color-background: #000000;
         --color-background-secondary: #121212;
     }
-    
+
 }
 
 * {
@@ -237,6 +237,12 @@ main, article {
     color: var(--color-content-secondary);
 }
 
+#footer .acknowledgement {
+    margin: 2rem auto 0;
+    text-align: center;
+    color: var(--color-content-secondary);
+}
+
 /* Sponsors Partial (_partials/sponsors.html) */
 /* ---------------------------------------- */
 
@@ -294,7 +300,7 @@ main, article {
     #home .full {
         width: 100%;
     }
-    
+
     #header {
         border-bottom: none;
         max-width: var(--width-site);
@@ -322,6 +328,12 @@ main, article {
 
     #footer {
         padding: 2rem 1rem;
+    }
+
+    #footer .acknowledgement {
+        max-width: var(--width-site);
+        margin-left: auto;
+        margin-right: auto;
     }
 
     #footer nav ul {


### PR DESCRIPTION
Adds a small acknowledgement of country in the footer of the page, below the copyright.

The wording I've chosen to use for this is one I found from a few sources. I think it is inclusive of everyone, but I'm very willing to be corrected (please check my work!):

> Melbourne CocoaHeads acknowledge the people of the Kulin nations as the Traditional Custodians of the land on which we live and work, recognising their continuing connection to land, water and community. We pay our respects to them and their cultures and to elders both past and present.​ 

Screenie:

![Screen Shot 2020-08-26 at 09 02 52](https://user-images.githubusercontent.com/790199/91236443-3c7c6380-e77b-11ea-9934-9d788ab18bc0.png)
