### PR TITLE
Update link for Slack invitations 

### DIFF
--- a/source/config.yml
+++ b/source/config.yml
@@ -8,6 +8,6 @@ params:
   socials:
     twitter: https://www.twitter.com/melbournecocoa
     meetup: https://www.meetup.com/Melbourne-CocoaHeads
-    slack: https://slack.melbournecocoaheads.com/
+    slack: https://join.slack.com/t/melbournecocoa/shared_invite/zt-85ixdbb8-1Wbqg4RB8KI93ccB~TqwHA
     github: https://www.github.com/melbournecocoa
     youtube: https://www.youtube.com/channel/UCpTDVzUkk9ieAyVyUi28bWw

--- a/source/content/about.md
+++ b/source/content/about.md
@@ -24,6 +24,6 @@ Melbourne CocoaHeads is managed by Melbourne CocoaHeads Inc; an incorporated ass
 * [Melbourne CocoaHeads on Meetup.com](https://www.meetup.com/Melbourne-CocoaHeads)
 * [YouTube](http://www.youtube.com/channel/UCpTDVzUkk9ieAyVyUi28bWw)
 * [Melbourne CocoaHeads History](https://github.com/melbournecocoa/MelbourneCocoaheadsHistory)
-* [Slack - @melbournecocoa](https://slack.melbournecocoaheads.com/) - click for an invite
+* [Slack - @melbournecocoa]({{<slacklink>}}) - click for an invite
 * [Twitter - @melbournecocoa](https://www.twitter.com/melbournecocoa)
 * [Github](https://github.com/melbournecocoa)

--- a/source/content/talks.md
+++ b/source/content/talks.md
@@ -2,4 +2,4 @@
 title: Submit a Talk
 ---
 
-Learned something new, built something nifty, or just got something you'd like to show? Join us on [Slack](https://slack.melbournecocoaheads.com/) and tell us your idea!
+Learned something new, built something nifty, or just got something you'd like to show? Join us on [Slack]({{<slacklink>}}) and tell us your idea!

--- a/source/layouts/shortcodes/slacklink.html
+++ b/source/layouts/shortcodes/slacklink.html
@@ -1,0 +1,1 @@
+{{ .Site.Params.Socials.Slack }}


### PR DESCRIPTION
Previously, we had some Heroku thing which ran a slack inviter. It was killed by the Heroku Lords, so it no longer works. We don’t need it, though. Slack provides one now. We’ll use the Slack-provided one.
