### PR TITLE
Fix word break/event details text wrapping issue

### DIFF
--- a/source/static/style.css
+++ b/source/static/style.css
@@ -154,7 +154,7 @@ main, article {
 }
 
 #event-details p {
-  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 #home #event-details a {

--- a/source/static/style.css
+++ b/source/static/style.css
@@ -153,6 +153,10 @@ main, article {
     text-align: left;
 }
 
+#event-details p {
+  word-break: break-word;
+}
+
 #home #event-details a {
     display: inline;
     color: var(--color-accent);


### PR DESCRIPTION
Fixes a small CSS issue I noticed the other night, in which main paragraph text inside `#event-details` was not wrapping/containing itself inside the parent element properly.

Since I wrote a quick fix for this, but before I could open a PR, the `/v1/event/next?group=melcch` endpoint inside home.html is now returning new description text, which does not exhibit this issue. Figured I'd open the PR anyway as it may help in future, especially if similar event descriptions are being used for upcoming coding night events. 

You could probably replicate this by asking for the specific previous event through that API, but I'm not familiar with its design. You could also copy some of the offending HTML straight into the `#event-detail` div: 

```html
<p>
  Before arrival, make sure you're grabbing a fresh copy of Xcode from the Mac App Store (Apple Menu then App Store
  then search for Xcode, Install. Link: <a href="https://itunes.apple.com/au/app/xcode/id497799835">https://itunes.apple.com/au/app/xcode/id497799835</a>mt=12)
</p>
```

Seemed to just be that the link text wasn't breaking, which pushed everything out to the side. It would potentially be possible to fix this by setting a width on `#event-details`, but that may still require some text-wrapping CSS anyway. 

| Before    | After |
| -------- | ------- |
| ![IMG_0674](https://github.com/user-attachments/assets/d32c19ef-79fe-421e-918c-4bdeb3d109a3)  |  ![IMG_0675](https://github.com/user-attachments/assets/71197e36-509d-4ab6-b46c-0fce5340b447)   |



